### PR TITLE
[REFACTOR]: modal logic change / useState to Redux

### DIFF
--- a/shoppingApp/src/App.tsx
+++ b/shoppingApp/src/App.tsx
@@ -6,12 +6,14 @@ import Header from './components/layouts/Header';
 import Footer from './components/layouts/Footer';
 import Products from './pages/products/Products';
 import ToastContainer from './components/toast/ToastContainer';
+import Modal from './components/modal/Modal';
 
 const App = () => {
   return (
     <BrowserRouter>
       <Header />
       <ToastContainer />
+      <Modal />
       <Routes>
         <Route path="/" element={<Main />} />
         <Route path="/bookmark" element={<Bookmark />} />

--- a/shoppingApp/src/components/modal/Modal.tsx
+++ b/shoppingApp/src/components/modal/Modal.tsx
@@ -1,25 +1,23 @@
 import BackDrop from './BackDrop';
 import { createPortal } from 'react-dom';
 import ModalImage from './ModalImage';
-import ModalProps from '../../types/ModalProps';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../modules';
 
 const portalElement = document.getElementById('modal') as HTMLElement;
 
-const Modal = ({ setIsOpen, src, product, title }: ModalProps) => {
+const Modal = () => {
+  const isModalOpen = useSelector((state: RootState) => state.modal.isOpen);
   return (
     <>
-      {createPortal(
-        <>
-          <BackDrop />
-          <ModalImage
-            setIsOpen={setIsOpen}
-            src={src}
-            product={product}
-            title={title}
-          />
-        </>,
-        portalElement,
-      )}
+      {isModalOpen &&
+        createPortal(
+          <>
+            <BackDrop />
+            <ModalImage />
+          </>,
+          portalElement,
+        )}
     </>
   );
 };

--- a/shoppingApp/src/components/modal/ModalImage.tsx
+++ b/shoppingApp/src/components/modal/ModalImage.tsx
@@ -1,35 +1,43 @@
 import BookMarkStar from '../../assets/icons/BookMarkStar';
 import { starActiveColor, starNonActiveColor } from '../../colors/colors';
 import Delete from '../../assets/icons/Delete';
-import ModalProps from '../../types/ModalProps';
 import useBookmark from '../../hooks/useBookmark';
-import React from 'react';
 import { showToastAsync } from '../../modules/toastSlice';
 import { useDispatch } from 'react-redux';
 import createToastMessage from '../../utils/createToastMessage';
-
+import { useSelector } from 'react-redux';
+import { RootState } from '../../modules';
+import { closeModal } from '../../modules/modalSlice';
+import { ProductType, useGetProductQuery } from '../../modules/productApi';
+import Loading from '../loading/Loading';
+import Error from '../loading/Error';
 const ModalImageWidth = '46.5rem';
 const ModalImageHeight = '30rem';
 
-const ModalImage = ({ product, src, title, setIsOpen }: ModalProps) => {
+const ModalImage = () => {
+  const { data, isLoading, isError } = useGetProductQuery(undefined);
   const bookMarkHandler = useBookmark();
   const dispatch = useDispatch();
+  const modalState = useSelector((state: RootState) => state.modal);
+  const findModalIndex = data.findIndex(
+    (product: ProductType) => product.id === modalState.product.id,
+  );
+
+  if (isLoading) return <Loading />;
+  if (isError || !data) return <Error />;
 
   return (
     <figure className="fixed bottom-0 left-0 right-0 top-0 z-20 flex items-center justify-center ">
       <div className={`relative h-[30rem] w-[46.5rem]`}>
         <button
-          onClick={(event: React.MouseEvent) => {
-            console.log(event);
-            setIsOpen((state) => !state);
-          }}
           className=" absolute right-[2.875rem] top-[3.125rem] cursor-pointer"
+          onClick={() => dispatch(closeModal())}
         >
           <Delete />
         </button>
         <img
           className={`rounded-3xl shadow-md shadow-slate-400 h-[${ModalImageHeight}] w-[${ModalImageWidth}]`}
-          src={src}
+          src={modalState.src}
           width={ModalImageWidth}
           height={ModalImageHeight}
         />
@@ -37,16 +45,26 @@ const ModalImage = ({ product, src, title, setIsOpen }: ModalProps) => {
           <div className=" flex">
             <button
               onClick={() => {
-                bookMarkHandler(product);
-                dispatch(showToastAsync(createToastMessage(!product.bookmark)));
+                bookMarkHandler(data[findModalIndex]);
+                dispatch(
+                  showToastAsync(
+                    createToastMessage(!data[findModalIndex].bookmark),
+                  ),
+                );
               }}
             >
               <BookMarkStar
                 className=" cursor-pointer"
-                fill={product.bookmark ? starActiveColor : starNonActiveColor}
+                fill={
+                  data[findModalIndex].bookmark
+                    ? starActiveColor
+                    : starNonActiveColor
+                }
               />
             </button>
-            <span className=" px-2 text-xl font-bold text-white">{title}</span>
+            <span className=" px-2 text-xl font-bold text-white">
+              {modalState.title}
+            </span>
           </div>
         </div>
       </div>

--- a/shoppingApp/src/components/productCard/BrandCard.tsx
+++ b/shoppingApp/src/components/productCard/BrandCard.tsx
@@ -1,28 +1,23 @@
 import ProductImage from './ProductImage';
 import { imageWidth } from '../../variable/ImageWH';
 import CardProps from '../../types/CardProps';
-import { useState } from 'react';
-import Modal from '../modal/Modal';
+import { useDispatch } from 'react-redux';
+import { openModal } from '../../modules/modalSlice';
+import modalAttributeMatcher from '../../utils/modalAttributeMatcher';
 
 const BrandCard = ({ product }: CardProps) => {
   const { brand_name, brand_image_url, follower } = product;
-
-  const [isOpen, setIsOpen] = useState(false);
+  const dispatch = useDispatch();
+  const modalArguments = modalAttributeMatcher(product);
 
   if (brand_image_url === null) return <div>에러</div>;
-
   return (
     <figure className={`flex flex-col max-w-[${imageWidth}]`}>
-      {isOpen && (
-        <Modal
-          setIsOpen={setIsOpen}
-          src={brand_image_url}
-          product={product}
-          title={brand_name as string}
-        />
-      )}
       <ProductImage src={brand_image_url} product={product} />
-      <div onClick={() => setIsOpen((state) => !state)} className="cardtext">
+      <div
+        className="cardtext"
+        onClick={() => dispatch(openModal(modalArguments))}
+      >
         <div className=" flex items-center justify-between">
           <span>{brand_name}</span>
           <span>관심고객수</span>

--- a/shoppingApp/src/components/productCard/CategoryCard.tsx
+++ b/shoppingApp/src/components/productCard/CategoryCard.tsx
@@ -1,27 +1,21 @@
 import ProductImage from './ProductImage';
 import { imageWidth } from '../../variable/ImageWH';
 import CardProps from '../../types/CardProps';
-import Modal from '../modal/Modal';
-import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import modalAttributeMatcher from '../../utils/modalAttributeMatcher';
+import { openModal } from '../../modules/modalSlice';
 
 const CategoryCard = ({ product }: CardProps) => {
   const { title, image_url } = product;
-  const [isOpen, setIsOpen] = useState(false);
+  const dispatch = useDispatch();
+  const modalArguments = modalAttributeMatcher(product);
 
   return (
     <figure className={`max-w-[${imageWidth}] flex flex-col`}>
-      {isOpen && (
-        <Modal
-          setIsOpen={setIsOpen}
-          src={image_url}
-          product={product}
-          title={title}
-        />
-      )}
       <ProductImage src={image_url} product={product} />
       <div
-        onClick={() => setIsOpen((state) => !state)}
         className="cardtext flex"
+        onClick={() => dispatch(openModal(modalArguments))}
       >
         <p># {title}</p>
       </div>

--- a/shoppingApp/src/components/productCard/ExhibitonCard.tsx
+++ b/shoppingApp/src/components/productCard/ExhibitonCard.tsx
@@ -1,28 +1,21 @@
 import ProductImage from './ProductImage';
 import { imageWidth } from '../../variable/ImageWH';
 import CardProps from '../../types/CardProps';
-import { useState } from 'react';
-import Modal from '../modal/Modal';
+import { openModal } from '../../modules/modalSlice';
+import { useDispatch } from 'react-redux';
+import modalAttributeMatcher from '../../utils/modalAttributeMatcher';
 
 const ExhibitionCard = ({ product }: CardProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-
   const { title, sub_title, image_url } = product;
+  const dispatch = useDispatch();
+  const modalArguments = modalAttributeMatcher(product);
 
   return (
     <figure className={`flex flex-col max-w-[${imageWidth}]`}>
-      {isOpen && (
-        <Modal
-          setIsOpen={setIsOpen}
-          src={image_url}
-          product={product}
-          title={title}
-        />
-      )}
       <ProductImage src={image_url} product={product} />
       <div
-        onClick={() => setIsOpen((state) => !state)}
         className="cardtext flex flex-col"
+        onClick={() => dispatch(openModal(modalArguments))}
       >
         <p>{title}</p>
         <p>{sub_title}</p>

--- a/shoppingApp/src/components/productCard/ProductCard.tsx
+++ b/shoppingApp/src/components/productCard/ProductCard.tsx
@@ -1,24 +1,22 @@
 import ProductImage from './ProductImage';
 import { imageWidth } from '../../variable/ImageWH';
 import CardProps from '../../types/CardProps';
-import Modal from '../modal/Modal';
-import { useState } from 'react';
-const ProductCard = ({ product }: CardProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+import { useDispatch } from 'react-redux';
+import modalAttributeMatcher from '../../utils/modalAttributeMatcher';
+import { openModal } from '../../modules/modalSlice';
 
+const ProductCard = ({ product }: CardProps) => {
   const { title, price, discountPercentage, image_url } = product;
+  const dispatch = useDispatch();
+  const modalArguments = modalAttributeMatcher(product);
+
   return (
     <figure className={`max-w-[${imageWidth}] flex flex-col`}>
-      {isOpen && (
-        <Modal
-          setIsOpen={setIsOpen}
-          src={image_url}
-          product={product}
-          title={title}
-        />
-      )}
       <ProductImage src={image_url} product={product} />
-      <div onClick={() => setIsOpen((state) => !state)} className=" cardtext ">
+      <div
+        className=" cardtext "
+        onClick={() => dispatch(openModal(modalArguments))}
+      >
         <div className=" flex items-center justify-between">
           <span className=" flex-shrink-0 overflow-hidden text-ellipsis">
             {title}

--- a/shoppingApp/src/modules/index.ts
+++ b/shoppingApp/src/modules/index.ts
@@ -4,12 +4,14 @@ import { ProductApi } from './productApi';
 import { setupListeners } from '@reduxjs/toolkit/query';
 import addBookmarkProperty from './middleware/addBookMarkProperty';
 import toastSlice from './toastSlice';
+import modalSlice from './modalSlice';
 
 const store = configureStore({
   reducer: {
     dark: darkSlice.reducer,
     [ProductApi.reducerPath]: ProductApi.reducer,
     toast: toastSlice.reducer,
+    modal: modalSlice.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(ProductApi.middleware, addBookmarkProperty),

--- a/shoppingApp/src/modules/modalSlice.ts
+++ b/shoppingApp/src/modules/modalSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ProductType } from './productApi';
+
+export interface ModalType {
+  isOpen: boolean;
+  src: string;
+  title: string;
+  product: ProductType;
+}
+
+const initialState: ModalType = {
+  isOpen: false,
+  src: '',
+  title: '',
+  product: {} as ProductType,
+};
+
+const modalSlice = createSlice({
+  name: 'modalSlice',
+  initialState,
+  reducers: {
+    openModal: (state, action: PayloadAction<ModalType>) => {
+      const { src, title, product } = action.payload;
+      state.isOpen = true;
+      state.src = src;
+      state.title = title;
+      state.product = product;
+    },
+    closeModal: (state) => {
+      state.isOpen = false;
+      state.src = '';
+      state.title = '';
+      state.product = {} as ProductType;
+    },
+  },
+});
+
+export const { openModal, closeModal } = modalSlice.actions;
+export default modalSlice;

--- a/shoppingApp/src/utils/modalAttributeMatcher.ts
+++ b/shoppingApp/src/utils/modalAttributeMatcher.ts
@@ -1,0 +1,22 @@
+import { ProductType } from '../modules/productApi';
+import { ModalType } from '../modules/modalSlice';
+
+const modalAttributeMatcher = (product: ProductType) => {
+  const matchedObj: ModalType = {
+    title: '매칭되는 상품 정보가 없습니다.',
+    src: 'default img url',
+    isOpen: false,
+    product: product,
+  };
+
+  matchedObj.title = (
+    product.title ? product.title : product.brand_name
+  ) as string;
+  matchedObj.src = (
+    product.image_url ? product.image_url : product.brand_image_url
+  ) as string;
+
+  return matchedObj;
+};
+
+export default modalAttributeMatcher;


### PR DESCRIPTION
@sujinleeme

```
안녕하세요 수진님! 

코드스테이츠 44기 프론트엔드 과정에서 

수진님 소그룹에 속해있는 유길종입니다

저는 현재 솔로프로젝트의 코드를 리팩토링하는 중에 있습니다.

이에 대하여 코드 리뷰를 부탁드리고 싶어요!

코드에 대한 설명은 아래에서하겠습니다.

```

# 리팩토링 목적

이전 코드에서는 Modal이 거의 최하위에 위치한 컴포넌트에 종속되어있던 상태였으며

구현은 useState를 이용하여 하고 있었습니다.

따라서 1차 코드리뷰에서 윤희님이 Modal은 전역적으로 관리되는 것이 맞을 것 같다는 이야기를 해주셔서

 Modal에 대한 로직을 ReduxToolkit을 이용해 전역적으로 관리되도록  리팩토링 하였습니다.

다만 그 과정에서 어려운 점이 있었습니다.


# 시연 화면

![testGif2](https://github.com/XionWCFM/fe-sprint-coz-shopping/assets/101111364/e5ad51e2-71f7-4089-9496-5a4c4a2484b1)

이 PR은 기존 useState로 동작하던 modal을 reduxToolkit으로 로직을 옮겨준 PR입니다.

우선은 동작하는 코드의 형태로 만들어서 PR을 보내두었습니다.

하지만 동작하게 하는 과정에서 비용이 비싼 로직을 사용하게 되어서 이를 다시 리팩토링해야할 것 같은데

어떻게 리팩토링할지에 대해 고민이 있는 상태입니다.


# 의아하실 수 있는 코드에 대한 설명

```tsx
ModalImage.tsx

const ModalImage = () => {
  const { data, isLoading, isError } = useGetProductQuery(undefined);
  const bookMarkHandler = useBookmark();
  const dispatch = useDispatch();
  const modalState = useSelector((state: RootState) => state.modal);
  const findModalIndex = data.findIndex(
    (product: ProductType) => product.id === modalState.product.id,
  );

  if (isLoading) return <Loading />;
  if (isError || !data) return <Error />;
```

왜 `ModalImage`에서 `useGetProductQuery`를 구독해야했냐하면

기존 코드에서는 props로 구독했던 쿼리데이터를 받아서 화면에 뿌려주는 형태였으며

그 쿼리데이터에 변화가 생기면 리렌더링도 제대로 일어났습니다.

그러나 Modal 로직을 `modalSlice`라는 별개의 상태를 만들어 관리하다보니

`modalSlice`의 bookmark 데이터를 화면에 뿌려주면 모달창이 켜진 상태에서 북마크 상태를 변경시키면

```
쿼리 데이터 : 북마크 상태가 변경됨

모달 데이터 : 쿼리 데이터와는 별개의 상태이기 때문에 쿼리 데이터의 북마크 상태가 변경된것을 감지하지 못함
```

이라는 문제가 발생해서 모달창의 북마크 상태가 변화하지 않는 문제가 있었습니다.

따라서 이 문제를 해결하기 위해 `ModalImage`에서 쿼리데이터를 구독해야할 필요가 있었고

어떤 프로덕트가 모달에 표시되고 있는지를 알아야했기에 findIndex를 돌릴 수밖에 없었기에

다음과 같은 코드를 작성해야했습니다.


하지만 Modal이 띄워질때마다 선형탐색을 진행하는것은 비효율적이라고 생각합니다.

왜냐하면 어떤 아이디를 가진 데이터가 모달에 띄워지고 있는지에 대한 정보는 이미 가지고 있기 때문입니다.


따라서 이에 대하여 제가 시도한 방법을 포함해 세가지 정도의 솔루션이 있을 것 같습니다.

<br>

1. 아쉽지만 현재 방식을 유지 `ModalImage`에서 findIndex를 통해 탐색한다.

2. 로컬스토리지 및 쿼리데이터 로직을 해쉬맵 형태로 바꿔주어 아이디만 알고있다면 O(1)로 탐색이 가능하게 리팩토링한다.

3. modalSlice에 새로운 action을 만들어 북마크 클릭 이벤트가 발생했을때 


``` tsx

dispatch(modalBookMarkToggle(product))

```

이런 형식의 액션을 실행시켜 modalSlice의 북마크 데이터도 클릭 이벤트가 발생하면 같이 바뀌게한다.


혹시 이 세가지 방법 중 어떤 방법이 제일 낫다고 생각하시는지

아니면 세가지 다 별로라고 생각하시는지 의견이 궁금합니다.


---

# 자료구조 개선에 대해서

현재는 로컬스토리지, 쿼리데이터 모두 배열로 관리하고 있기 때문에

선형 탐색으로 요소를 찾는 선택지 밖에 존재하지 않습니다.

따라서 이에 대한 솔루션을 여러가지 시도해보고 생각해봤는데 각자 트레이드 오프가 있어서 어려운 것 같습니다.

처음에는 Map 자료구조와 Set 자료구조를 활용해 문제를 해결해보려고했는데

로컬스토리지에 Map 자료구조가 그대로 들어갈 수가 없다는 문제가 있어서 보류하게되었습니다.


현재 드는 생각으로는 애초부터 미들웨어를 통해 배열형태로 온 데이터를

객체로 변환하여

```tsx
const querydata = {
  id : { product 객체 }
}
```
의 형태로 관리하고 로컬스토리지 역시 객체의 형태로 저장을 해주면서

북마크가 있는지 확인할 때는 id를 기반으로 빠르게 확인하고

화면에 렌더 시킬때는 

`Object.values` 혹은 `Obejct.entries` 정적 메서드를 이용해 오브젝트를 배열화시키고 .map을 돌리는 방식으로 

하면 되지 않을까 싶습니다.


그런데 막상 객체 안에 객체가 들어가 있으면서 객체의 프로퍼티가 몇개일지 예상할 수 없는 경우에는

타입스크립트로 어떻게 객체에 타입을 주어야할지 모르겠더라구요..



그래서 혹시 이런 경우에는 타입을 그냥 Object로 주고 사용하는지 아니면 어떤 솔루션이 있는지 궁금하고

제가 생각한 방법보다 더 좋은 방법이 있는지 궁금합니다.

